### PR TITLE
Simplify

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,14 @@
 
 const pattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:https?|ftp):\/\/[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi
 
-module.exports = (content, opts = {}) => {
-  const attrs = Object.keys(opts).map(key => key === 'callback' ? '' : ` ${key}="${opts[key]}"`).join('')
+function getAttrs(key) {
+	return key === 'callback' ? '' : ` ${key}="${this[key]}"`
+}
+function replacer(match, space, url) {
+	return this.callback ? this.callback(url) : `${space}<a href="${url}"${this.attrs}>${url}</a>`
+}
 
-  return content.replace(pattern, (match, space, url) =>
-    opts.callback ? opts.callback(url) : `${space}<a href="${url}"${attrs}>${url}</a>`
-  )
+module.exports = (content, opts = {}) => {
+  opts.attrs = Object.keys(opts).map(getAttrs, opts).join('')
+  return content.replace(pattern, replacer.bind(opts))
 }

--- a/index.js
+++ b/index.js
@@ -1,39 +1,11 @@
 'use strict'
 
-module.exports = (content, opt) => {
-  let callback
-  let key
-  let linkAttributes
-  let option
-  let options
-  let pattern
-  let value
+const pattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:https?|ftp):\/\/[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi
 
-  options = opt
-  pattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:https?|ftp):\/\/[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi
+module.exports = (content, opts = {}) => {
+  const attrs = Object.keys(opts).map(key => key === 'callback' ? '' : ` ${key}="${opts[key]}"`).join('')
 
-  if (!(options.length > 0)) {
-    return content.replace(pattern, "$1<a href='$2'>$2</a>")
-  }
-
-  option = options[0]
-  callback = option['callback']
-  linkAttributes = ((() => {
-    let results
-
-    results = []
-    for (key in option) {
-      value = option[key]
-      if (key !== 'callback') {
-        results.push(' ' + key + '="' + value + '"')
-      }
-    }
-    return results
-  })()).join('')
-
-  return content.replace(pattern, (match, space, url) => {
-    var link
-    link = (typeof callback === 'function' ? callback(url) : void 0) || ('<a href="' + url + '"' + linkAttributes + '>' + url + '</a>')
-    return '' + space + link
-  })
+  return content.replace(pattern, (match, space, url) =>
+    opts.callback ? opts.callback(url) : `${space}<a href="${url}"${attrs}>${url}</a>`
+  )
 }


### PR DESCRIPTION
- It works now ([the examples didn't work before](https://runkit.com/57c558abc2fdcc130060993e/57f3a036cddb9314009beea9/branches/master) because it wanted an array but the docs specified an object)
- Uses constants
- Avoids unnecessary IIFEs
- Avoids unnecessary intermediary variables
- Uses `Object.keys` instead of the [dangerous `for...in`](http://eslint.org/docs/rules/guard-for-in)
- Clarifies replacer function
